### PR TITLE
Remove Deprecated code; prepare for D9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
       "role": "Maintainer"
     }
   ],
-  "require":{
+  "require": {
+    "drupal/core": "^8 || ^9",
     "symfony/ldap": "~3.4"
   }
 }

--- a/src/Form/MultiStep/UserImportStepTwoForm.php
+++ b/src/Form/MultiStep/UserImportStepTwoForm.php
@@ -4,6 +4,7 @@ namespace Drupal\unl_user\Form\MultiStep;
 
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
 use Drupal\unl_user\Form\UserImportForm;
 use Drupal\unl_user\Helper;
@@ -33,7 +34,7 @@ class UserImportStepTwoForm extends UserImportForm {
     
     if (empty($results)) {
       //No results could be found, so restart the process
-      drupal_set_message($this->t('No results could be found for: @search', array('@search' => $search)), 'error');
+      $this->messenger()->addError($this->t('No results could be found for: @search', ['@search' => $search]));
       $form_state->setRedirect('unl_user.user_import');
 
       $form['actions']['#type'] = 'actions';
@@ -89,7 +90,7 @@ class UserImportStepTwoForm extends UserImportForm {
     $helper = new Helper();
     $user = $helper->initializeUser($form_state->getValue('uid'));
     
-    drupal_set_message($this->t('imported @uid', array('@uid' => $form_state->getValue('uid'))));
+    $this->messenger()->addStatus($this->t('imported @uid', ['@uid' => $form_state->getValue('uid')]));
     
     //Redirect to the edit the new user
     $form_state->setRedirect('entity.user.edit_form',array('user' => $user->id()));

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -59,9 +59,9 @@ class SettingsForm extends ConfigFormBase {
     $affiliation = \Drupal::service('user.data')->get('unl_user', \Drupal::currentUser()->id(), 'primaryAffiliation');
 
     if (!$result || $result['data']['unl']['source'] !== PersonDataQuery::SOURCE_LDAP) {
-      drupal_set_message($this->t('LDAP is NOT being used. Please ensure credentials are correct. Your primary affiliation is: @affiliation', ['@affiliation'=>$affiliation]), 'warning');
+      $this->messenger()->addWarning($this->t('LDAP is NOT being used. Please ensure credentials are correct. Your primary affiliation is: @affiliation', ['@affiliation' => $affiliation]));
     } else {
-      drupal_set_message($this->t('LDAP is being used, your primary affiliation is: @affiliation', ['@affiliation'=>$affiliation]));
+      $this->messenger()->addStatus($this->t('LDAP is being used, your primary affiliation is: @affiliation', ['@affiliation' => $affiliation]));
     }
     
     return parent::buildForm($form, $form_state);

--- a/src/Form/UserImportForm.php
+++ b/src/Form/UserImportForm.php
@@ -3,7 +3,7 @@
 namespace Drupal\unl_user\Form;
 
 use Drupal\Core\Form\FormBase;
-use Drupal\user\PrivateTempStoreFactory;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class UserImportForm extends FormBase {
 
   /**
-   * @var \Drupal\user\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
   protected $store;
   

--- a/src/Tests/ImportUserTest.php
+++ b/src/Tests/ImportUserTest.php
@@ -2,14 +2,19 @@
 
 namespace Drupal\unl_user\Tests;
 
-use Drupal\simpletest\WebTestBase;
+use Drupal\Tests\BrowserTestBase;
 
 /**
  * Tests for the unl_user module.
  * @group unl_user
  */
-class ImportUserTest extends WebTestBase
+class ImportUserTest extends BrowserTestBase
 {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to install

--- a/src/Tests/ImportUserTest.php
+++ b/src/Tests/ImportUserTest.php
@@ -54,6 +54,6 @@ class ImportUserTest extends BrowserTestBase
     ), t('Import Selected User'));
     $this->assertText('imported test-user2', 'able to import a user');
 
-    $this->assertTrue(preg_match('/user\/(\d)\/edit/', $this->getUrl()), 'Should take you to the edit page for the new user');
+    $this->assertTrue((bool) preg_match('/user\/(\d)\/edit/', $this->getUrl()), 'Should take you to the edit page for the new user');
   }
 }

--- a/unl_user.info.yml
+++ b/unl_user.info.yml
@@ -3,7 +3,7 @@ description: 'Enables UNL user data and functionality, including data importing.
 package: UNL
 
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9
 
 version: 1.x
 configure: unl_user.settings


### PR DESCRIPTION
Prepare for D9

- Remove deprecated code
- Update composer.json
- Update *.info.yml

Drupal-check results:
```
$ drupal-check unl_user
 9/9 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ---------------------------------------------------------------------- 
  Line   src/Form/MultiStep/UserImportStepTwoForm.php                          
 ------ ---------------------------------------------------------------------- 
  36     Call to deprecated function drupal_set_message():                     
         in drupal:8.5.0 and is removed from drupal:9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  92     Call to deprecated function drupal_set_message():                     
         in drupal:8.5.0 and is removed from drupal:9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   src/Form/SettingsForm.php                                             
 ------ ---------------------------------------------------------------------- 
  62     Call to deprecated function drupal_set_message():                     
         in drupal:8.5.0 and is removed from drupal:9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  64     Call to deprecated function drupal_set_message():                     
         in drupal:8.5.0 and is removed from drupal:9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   src/Form/UserImportForm.php                                           
 ------ ---------------------------------------------------------------------- 
  19     Parameter $temp_store_factory of method                               
         Drupal\unl_user\Form\UserImportForm::__construct() has typehint with  
         deprecated class Drupal\user\PrivateTempStoreFactory:                 
         in drupal:8.5.0 and is removed from drupal:9.0.0.                     
         Use \Drupal\Core\TempStore\PrivateTempStoreFactory instead.           
 ------ ---------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------- 
  Line   src/Tests/ImportUserTest.php                                         
 ------ --------------------------------------------------------------------- 
  11     Class Drupal\unl_user\Tests\ImportUserTest extends deprecated class  
         Drupal\simpletest\WebTestBase:                                       
         in drupal:8.8.0 and is removed from drupal:9.0.0. Instead,           
         use \Drupal\Tests\BrowserTestBase. See                               
         https://www.drupal.org/node/3030340.                                 
  25     Call to method setUp() of deprecated class                           
         Drupal\simpletest\WebTestBase:                                       
         in drupal:8.8.0 and is removed from drupal:9.0.0. Instead,           
         use \Drupal\Tests\BrowserTestBase. See                               
         https://www.drupal.org/node/3030340.                                 
 ------ --------------------------------------------------------------------- 

                                                                                
 [ERROR] Found 7 errors                                                         
                                                                                
```