### PR TITLE
Invalid arguments passed to implode()

### DIFF
--- a/src/Form/MultiStep/UserImportStepTwoForm.php
+++ b/src/Form/MultiStep/UserImportStepTwoForm.php
@@ -45,11 +45,17 @@ class UserImportStepTwoForm extends UserImportForm {
       
       return $form; //exit early
     }
-    
+
     $matches = [];
     foreach ($results as $details) {
-      $affiliations = implode(', ', $details['data']['unl']['affiliations']);
-      $matches[$details['uid']] = $details['data']['unl']['fullName'] . ' (' . $affiliations . ') (' . $details['uid'] . ')';
+      // Generate an affiliations string if user has any affiliations.
+      if ($details['data']['unl']['affiliations']) {
+        $affiliations = ' (' . implode(', ', $details['data']['unl']['affiliations']) . ')';
+      }
+      else {
+        $affiliations = '';
+      }
+      $matches[$details['uid']] = $details['data']['unl']['fullName'] . $affiliations . ' (' . $details['uid'] . ')';
     }
 
     $form['uid'] = array(


### PR DESCRIPTION
When on step 2 of the import user form, the following warning is triggered for every result returned:
```
Warning: implode(): Invalid arguments passed in Drupal\unl_user\Form\MultiStep\UserImportStepTwoForm->buildForm() (line 52 of /var/www/html/web/modules/contrib/unl_user/src/Form/MultiStep/UserImportStepTwoForm.php)
```

Below is the code in question:
```php
$matches = [];
foreach ($results as $details) {
  $affiliations = implode(', ', $details['data']['unl']['affiliations']);
  $matches[$details['uid']] = $details['data']['unl']['fullName'] . ' (' . $affiliations . ') (' . $details['uid'] . ')';
}
```

It appears the code anticipates one or more affiliations in all cases.