### PR TITLE
Change test user

### DIFF
--- a/src/Tests/ImportUserTest.php
+++ b/src/Tests/ImportUserTest.php
@@ -45,9 +45,9 @@ class ImportUserTest extends WebTestBase
     $this->assertText('Records Found. Select a user to import.', 'Able to search for a user');
 
     $this->drupalPostForm(NULL, array(
-      'uid' => 'test-user2'
+      'uid' => 'hhusker1'
     ), t('Import Selected User'));
-    $this->assertText('imported test-user2', 'able to import a user');
+    $this->assertText('imported hhusker1', 'able to import a user');
 
     $this->assertTrue(preg_match('/user\/(\d)\/edit/', $this->getUrl()), 'Should take you to the edit page for the new user');
   }

--- a/src/Tests/PersonDataQueryTest.php
+++ b/src/Tests/PersonDataQueryTest.php
@@ -25,9 +25,9 @@ class PersonDataQueryTest extends UnitTestCase
   public function testGetUserData() {
     $query = new PersonDataQuery();
 
-    $result = $query->getUserData('test-user2');
+    $result = $query->getUserData('hhusker1');
 
-    $this->assertEquals($result['uid'], 'test-user2', 'uid should be set');
+    $this->assertEquals($result['uid'], 'hhusker1', 'uid should be set');
     
     $this->assertStandardPersonRecord($result);
   }


### PR DESCRIPTION
Tests are failing because they're trying to use a non-existent user from directory, 'test-user2'. 

This issue also seeks to change the test user from 'test-user2' to 'utesting3', which exists in the directory test environment.

Also, per Brett B:

> Brett B 2:43 PM (4/6/2020)
> We do not provision test accounts to our production identity environment, but we DO have a test environment that can be used for testing.

Affected tests:
- Drupal\unl_user\Tests\ImportUserTest::testImportUser()
- Drupal\unl_user\Tests\PersonDataQueryTest::testGetUserData()

~~This issue seeks to add a production/test mode. The toggle would affect which server is queried (directory.unl.edu or directory-test.unl.edu).~~